### PR TITLE
Ensure Compatibility with pytest > 5.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Change log for gocept.pytestlayer
 6.2 (unreleased)
 ================
 
-- Nothing changed yet.
+- Ensure compatibility with pytest > 5.4. We need a
+  ``_needs_explicit_tearDown`` on our ``LayeredTestCaseFunction`` now.
 
 
 6.1 (2020-02-20)

--- a/src/gocept/pytestlayer/layered.py
+++ b/src/gocept/pytestlayer/layered.py
@@ -45,6 +45,9 @@ class LayeredTestCaseFunction(_pytest.unittest.TestCaseFunction):
         self._testcase = self.parent.obj
 
     def setup(self):
+        # This is actually set in the base class, but as we want to modify
+        # `self._request` in our way, we do not make a super call here.
+        self._needs_explicit_tearDown = False
         if hasattr(self, "_request"):
             # call function fixture (testSetUp)
             fixture_name = fixture.get_fixture_name(

--- a/tox.ini
+++ b/tox.ini
@@ -19,10 +19,10 @@ setenv =
 extras = test
 deps =
     py{27,py}: pytest < 5.0
-    py{35,36,37,py3}: pytest != 5.3.4, != 5.3.3
+    py{35,36,37,38,py3}: pytest != 5.3.4, != 5.3.3
     pytest-cov
     pytest-flake8
-    pytest-remove-stale-bytecode
+    py{35,36,37,38,py3}: pytest-remove-stale-bytecode
 
 [testenv:coverage-report]
 deps = coverage


### PR DESCRIPTION
This should fix the tests. Currently the `setup()` of the base class does even more, which we partly do in the `__init__()`. It might be a consideration to change that too.