### PR TITLE
Ensure compatibility with pytest 5.4.2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Change log for gocept.pytestlayer
 6.3 (unreleased)
 ================
 
-- Nothing changed yet.
+- Ensure compatibility with pytest > 5.4.2. We need a
+  ``_explicit_tearDown`` on our ``LayeredTestCaseFunction`` now.
 
 
 6.2 (2020-03-20)

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,16 @@ setup(
     name='gocept.pytestlayer',
     version='6.3.dev0',
 
+    python_requires=', '.join([
+        '>=2.7',
+        '!=3.0.*',
+        '!=3.1.*',
+        '!=3.2.*',
+        '!=3.3.*',
+        '!=3.4.*',
+    ]),
     install_requires=[
-        'pytest>=3.0',
+        'pytest',
         'setuptools',
         'six',
         'zope.dottedname',
@@ -32,7 +40,7 @@ setup(
     author='gocept <mail@gocept.com>',
     author_email='mail@gocept.com',
     license='ZPL 2.1',
-    url='https://bitbucket.org/gocept/gocept.pytestlayer/',
+    url='https://github.com/gocept/gocept.pytestlayer/',
 
     keywords='pytest py.test zope.testrunner layer fixture',
     classifiers="""\

--- a/src/gocept/pytestlayer/layered.py
+++ b/src/gocept/pytestlayer/layered.py
@@ -47,7 +47,8 @@ class LayeredTestCaseFunction(_pytest.unittest.TestCaseFunction):
     def setup(self):
         # This is actually set in the base class, but as we want to modify
         # `self._request` in our way, we do not make a super call here.
-        self._needs_explicit_tearDown = False
+        # It has to be None or a bound method to be called during tearDown.
+        self._explicit_tearDown = None
         if hasattr(self, "_request"):
             # call function fixture (testSetUp)
             fixture_name = fixture.get_fixture_name(

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ setenv =
 extras = test
 deps =
     py{27,py}: pytest < 5.0
-    py{35,36,37,38,py3}: pytest != 5.3.4, != 5.3.3
+    py{35,36,37,38,py3}: pytest >= 5.4.2
     pytest-cov
     pytest-flake8
     py{35,36,37,38,py3}: pytest-remove-stale-bytecode


### PR DESCRIPTION
https://github.com/pytest-dev/pytest/pull/7151 changed the internal structure of teardowns again. 