### PR TITLE
Add a workaround for #4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,9 @@ on:
     type: [ "opened", "reopened", "synchronize" ]
   schedule:
     - cron: '0 12 * * 0'  # run once a week on Sunday
+  # Allow to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   tests:
     strategy:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ Change log for gocept.pytestlayer
 
 - Add support for Python 3.9.
 
+- Add a workaround for
+  `#4 <https://github.com/gocept/gocept.pytestlayer/issues/4>`_: Use
+  ``gcoept.pytestlayer.doctest.DocTestSuite`` instead of
+  ``doctest.DocTestSuite`` to circumvent the issue.
+
 
 7.0 (2020-08-03)
 ================

--- a/src/gocept/pytestlayer/doctest.py
+++ b/src/gocept/pytestlayer/doctest.py
@@ -1,0 +1,31 @@
+import doctest
+
+
+class NoOpLayer(object):
+    """Layer needed for gocept.pytestlayer to find and run doctests.
+
+    See https://github.com/gocept/gocept.pytestlayer/issues/4
+    """
+
+    __name__ = 'NoOpLayer'
+    __bases__ = ()
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+
+NOOP_LAYER = NoOpLayer()
+
+
+def DocTestSuite(*args, **kw):
+    """A DocTestSuite whose tests are detectable by gocept.pytestlayer.
+
+    See https://github.com/gocept/gocept.pytestlayer/issues/4
+    """
+    layer = kw.pop('layer', NOOP_LAYER)
+    suite = doctest.DocTestSuite(*args, **kw)
+    suite.layer = layer
+    return suite

--- a/src/gocept/pytestlayer/doctest.py
+++ b/src/gocept/pytestlayer/doctest.py
@@ -1,7 +1,7 @@
 import doctest
 
 
-class NoOpLayer(object):
+class NoOpLayer:
     """Layer needed for gocept.pytestlayer to find and run doctests.
 
     See https://github.com/gocept/gocept.pytestlayer/issues/4

--- a/src/gocept/pytestlayer/tests/test_doctest.py
+++ b/src/gocept/pytestlayer/tests/test_doctest.py
@@ -1,0 +1,16 @@
+from gocept.pytestlayer.doctest import DocTestSuite
+
+
+class Dummy:
+    """This class has a doctest.
+
+    It tests the workaround for
+    https://github.com/gocept/gocept.pytestlayer/issues/4
+
+    >>> print('foobar.')
+    foobar.
+    """
+
+
+def test_suite():
+    return DocTestSuite('gocept.pytestlayer.tests.test_doctest')


### PR DESCRIPTION
Use `gcoept.pytestlayer.doctest.DocTestSuite` instead of `doctest.DocTestSuite` to circumvent the issue.