### PR TITLE
update name for pytest

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,26 +15,26 @@ The gocept.pytestlayer distribution
     :target: https://coveralls.io/github/gocept/gocept.pytestlayer?branch=master
 
 
-Integration of zope.testrunner-style test layers into the `py.test`_
+Integration of zope.testrunner-style test layers into the `pytest`_
 framework
 
 This package is compatible with Python versions 3.6 - 3.9 including
 PyPy3.
 
-.. _`py.test` : http://pytest.org
+.. _`pytest` : http://pytest.org
 
 Quick start
 ===========
 
-* Make sure your test files follow the `conventions of py.test's test
+* Make sure your test files follow the `conventions of pytest's test
   discovery`_
 
-  .. _`conventions of py.test's test discovery`:
+  .. _`conventions of pytest's test discovery`:
      http://pytest.org/latest/goodpractises.html#python-test-discovery
 
   In particular, a file named ``tests.py`` will not be recognised.
 
-* Add a buildout section to create the `py.test` runner::
+* Add a buildout section to create the `pytest` runner::
 
     [buildout]
     parts += pytest
@@ -45,13 +45,13 @@ Quick start
            pytest
            <YOUR PACKAGE HERE>
 
-``gocept.pytestlayer`` registers itself as a ``py.test`` plugin. This way, nothing
+``gocept.pytestlayer`` registers itself as a ``pytest`` plugin. This way, nothing
 more is needed to run an existing Zope or Plone test suite.
 
 Advanced usage
 ==============
 
-Version 2.1 reintroduced `fixture.create()` to be able to define the name of the generated to py.test fixtures. So it is possible to use them in function style tests.
+Version 2.1 reintroduced `fixture.create()` to be able to define the name of the generated to pytest fixtures. So it is possible to use them in function style tests.
 
 Example (Code has to be in `contest.py`!)::
 
@@ -76,8 +76,8 @@ Not supported use cases
 
 * Mixing classes inheriting ``unittest.TestCase`` and a ``test_suite()`` function (e. g. to create a ``DocTestSuite`` or a ``DocFileSuite``) in a single module (aka file).
 
-  * This is a limitation of the `py.test` test discovery which ignores the doctests in this case.
+  * This is a limitation of the `pytest` test discovery which ignores the doctests in this case.
 
   * Solution: Put the classes and ``test_suite()`` into different modules.
 
-* A ``doctest.DocFileSuite`` which does not have a ``layer`` is silently skipped. Use the built-in doctest abilities of py.test to run those tests.
+* A ``doctest.DocFileSuite`` which does not have a ``layer`` is silently skipped. Use the built-in doctest abilities of pytest to run those tests.

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,7 @@
 # All addopts which is added here, will also be executed by the separate tests.
 # Therefore, either the tests have to be adopted (e.g. with normalizers or
 # rewritten) or the respective parameter have to be added to the initial
-# py.test call.
+# pytest call.
 # Note: calling --cov=src will not give the full coverage if called with the
 # initial call.
 # Note: adding 'src' to addpots might lead to recursion and huge memory usage.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-"""Integration of zope.testrunner-style test layers into py.test framework"""
+"""Integration of zope.testrunner-style test layers into pytest framework"""
 
 from setuptools import find_packages
 from setuptools import setup
@@ -37,7 +37,7 @@ setup(
     license='ZPL 2.1',
     url='https://github.com/gocept/gocept.pytestlayer/',
 
-    keywords='pytest py.test zope.testrunner layer fixture',
+    keywords='pytest zope.testrunner layer fixture',
     classifiers="""\
 Development Status :: 4 - Beta
 Environment :: Console

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ extras = test
 deps =
     pytest
     pytest-remove-stale-bytecode
-commands = py.test []
+commands = pytest []
 
 [testenv:coverage]
 basepython = python3
@@ -24,4 +24,4 @@ deps =
     coverage
     coverage-python-version
 commands =
-    py.test --cov=src --cov-report=html []
+    pytest --cov=src --cov-report=html []


### PR DESCRIPTION
It has been renamed from py.test to pytest quite a while ago.