### PR TITLE
Make tests compatible with pytest >= 7.3.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@ Change log for gocept.pytestlayer
 8.2 (unreleased)
 ================
 
-- Nothing changed yet.
+- Make tests compatible with pytest >= 7.3.
+
+- Add support for Python 3.11.
 
 
 8.1 (2022-09-05)

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ The gocept.pytestlayer distribution
 Integration of zope.testrunner-style test layers into the `pytest`_
 framework
 
-This package is compatible with Python versions 3.7 - 3.10 including
+This package is compatible with Python versions 3.7 - 3.11 including
 PyPy3.
 
 .. _`pytest` : http://pytest.org

--- a/setup.py
+++ b/setup.py
@@ -52,11 +52,11 @@ Natural Language :: English
 Operating System :: OS Independent
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3.10
+Programming Language :: Python :: 3.11
 Programming Language :: Python :: Implementation
 Programming Language :: Python :: Implementation :: CPython
 Programming Language :: Python :: Implementation :: PyPy

--- a/src/gocept/pytestlayer/tests/test_integration.py
+++ b/src/gocept/pytestlayer/tests/test_integration.py
@@ -13,19 +13,13 @@ normalizers = [
     (r'\.py::(test_suite)::/', r'.py <- \1: /'),
     (r'\.py::(test)', r'.py:NN: \1'),
     (r'\.py::(.*Test)::', r'.py:NN: \1.'),
-    # Compatibility with pytest <= 3.1.2; can be removed if no longer supported
-    ('1 items', '1 item'),
+    # Compatibility with pytest >= 7.3 which adds this line:
+    (r'configfile: pytest.ini', ''),
     # With pytest >= 3.3.0 progress is reported after a test result.
     # matches [NNN%], [ NN%] and [  N%]
     (r'PASSED \[\s*\d{1,3}%\]', 'PASSED'),
     # needed to omit all other loaded plugins.
     (r'plugins:.*(gocept.pytestlayer).*\n', 'plugins: gocept.pytestlayer\n'),
-    # can be removed when python 2.7 / pypy2 is no longer supported
-    (r"""\
-========================== deprecated python version ===========================
-You are using Python 2.7.\d{1,2}, which will no longer be supported in pytest 5.0
-For more information, please read:
-  https://docs.pytest.org/en/latest/py27-py34-deprecation.html""", ''),
 ]
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py38,
     py39,
     py310,
+    py311,
     pypy3,
     coverage,
 minversion = 2.4


### PR DESCRIPTION
Add support for Python 3.11 on the go.