### PR TITLE
Update Python version support.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,8 @@
-# Generated from:
-# https://github.com/zopefoundation/meta/tree/master/config/pure-python
+# Generated with zope.meta (https://zopemeta.readthedocs.io/) from:
+# https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 #
 # EditorConfig Configuration file, for more details see:
-# http://EditorConfig.org
+# https://EditorConfig.org
 # EditorConfig is a convention description, that could be interpreted
 # by multiple editors to enforce common coding conventions for specific
 # file types
@@ -12,7 +12,7 @@
 root = true
 
 
-[*]  # For All Files
+[*]
 # Unix-style newlines with a newline ending every file
 end_of_line = lf
 insert_final_newline = true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,5 +1,5 @@
-# Generated from:
-# https://github.com/zopefoundation/meta/tree/master/config/pure-python
+# Generated with zope.meta (https://zopemeta.readthedocs.io/) from:
+# https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 name: pre-commit
 
 on:
@@ -21,10 +21,10 @@ jobs:
     name: linting
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
-        python-version: 3.x
+        python-version: '3.13'
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  #v3.0.1
       with:
         extra_args: --all-files --show-diff-on-failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
-# Generated from:
-# https://github.com/zopefoundation/meta/tree/master/config/pure-python
+# Generated with zope.meta (https://zopemeta.readthedocs.io/) from:
+# https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 name: tests
 
 on:
@@ -24,12 +24,12 @@ jobs:
         config:
         # [Python version, tox env]
         - ["3.11", "release-check"]
-        - ["3.9", "py39"]
         - ["3.10", "py310"]
         - ["3.11", "py311"]
         - ["3.12", "py312"]
         - ["3.13", "py313"]
-        - ["pypy-3.10", "pypy3"]
+        - ["3.14", "py314"]
+        - ["pypy-3.11", "pypy3"]
         - ["3.11", "docs"]
         - ["3.11", "coverage"]
 
@@ -37,17 +37,18 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     name: ${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         persist-credentials: false
     - name: Install uv + caching
-      uses: astral-sh/setup-uv@v6
+      # astral/setup-uv@7.1.4
+      uses: astral-sh/setup-uv@1e862dfacbd1d6d858c55d9b792c756523627244
       with:
         enable-cache: true
         cache-dependency-glob: |
           setup.*
           tox.ini
-        python-version: ${{ matrix.matrix.config[0] }}
+        python-version: ${{ matrix.config[0] }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Test
       if: ${{ !startsWith(runner.os, 'Mac') }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-# Generated from:
-# https://github.com/zopefoundation/meta/tree/master/config/pure-python
+# Generated with zope.meta (https://zopemeta.readthedocs.io/) from:
+# https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 *.dll
 *.egg-info/
 *.profraw

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 [meta]
 template = "pure-python"
-commit-id = "462fe60b"
+commit-id = "f11c758e"
 
 [python]
 with-sphinx-doctests = false
@@ -21,12 +21,21 @@ testenv-deps = [
     "pytest-cov",
     "pytest-remove-stale-bytecode",
 ]
+coverage-setenv = [
+    "COVERAGE_FILE = {toxinidir}/.coverage",
+]
 coverage-command = [
-    "pytest --cov=src --cov-report=html []",
+    "coverage erase",
+    "pytest --cov=src --cov-report= -vs []",
     ]
 
 [coverage]
 fail-under = 98
+
+[coverage-run]
+additional-config = [
+    "parallel = true",
+    ]
 
 [flake8]
 additional-config = [
@@ -37,6 +46,7 @@ additional-config = [
 
 [manifest]
 additional-rules = [
+    "include *.py",
     "include *.yaml",
     "include pytest.ini",
     "recursive-include src *.txt",

--- a/.meta.toml
+++ b/.meta.toml
@@ -1,8 +1,8 @@
-# Generated from:
-# https://github.com/zopefoundation/meta/tree/master/config/pure-python
+# Generated with zope.meta (https://zopemeta.readthedocs.io/) from:
+# https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 [meta]
 template = "pure-python"
-commit-id = "3ea7ef32"
+commit-id = "462fe60b"
 
 [python]
 with-sphinx-doctests = false
@@ -13,7 +13,6 @@ with-macos = false
 with-windows = false
 
 [tox]
-use-flake8 = true
 testenv-commands = [
     "pytest []"
 ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     - id: autopep8
       args: [--in-place, --aggressive, --aggressive]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.0
+    rev: v3.21.2
     hooks:
     - id: pyupgrade
       args: [--py310-plus]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
-# Generated from:
-# https://github.com/zopefoundation/meta/tree/master/config/pure-python
+# Generated with zope.meta (https://zopemeta.readthedocs.io/) from:
+# https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 minimum_pre_commit_version: '3.6'
 repos:
   - repo: https://github.com/pycqa/isort
-    rev: "6.0.1"
+    rev: "7.0.0"
     hooks:
     - id: isort
   - repo: https://github.com/hhatto/autopep8
@@ -12,10 +12,10 @@ repos:
     - id: autopep8
       args: [--in-place, --aggressive, --aggressive]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.0
     hooks:
     - id: pyupgrade
-      args: [--py39-plus]
+      args: [--py310-plus]
   - repo: https://github.com/isidentical/teyit
     rev: 0.4.3
     hooks:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,5 @@
-# Generated from:
-# https://github.com/zopefoundation/meta/tree/master/config/pure-python
+# Generated with zope.meta (https://zopemeta.readthedocs.io/) from:
+# https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Change log for zope.pytestlayer
 9.1 (unreleased)
 ================
 
-- Nothing changed yet.
+- Add compatibility for ``pytest >= 9``.
 
 
 9.0 (2025-09-12)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Change log for zope.pytestlayer
 
 - Add compatibility for ``pytest >= 9``.
 
+- Add support for Python 3.13.
+
+- Drop support for Python 3.9.
+
 
 9.0 (2025-09-12)
 ================

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 <!--
-Generated from:
-https://github.com/zopefoundation/meta/tree/master/config/pure-python
+Generated with zope.meta (https://zopemeta.readthedocs.io/) from:
+https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 -->
 # Contributing to zopefoundation projects
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
-# Generated from:
-# https://github.com/zopefoundation/meta/tree/master/config/pure-python
+# Generated with zope.meta (https://zopemeta.readthedocs.io/) from:
+# https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 include *.md
 include *.rst
 include *.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@ recursive-include docs *.rst
 recursive-include docs Makefile
 
 recursive-include src *.py
+include *.py
 include *.yaml
 include pytest.ini
 recursive-include src *.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,12 @@
+# Generated with zope.meta (https://zopemeta.readthedocs.io/) from:
+# https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 # 
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 
 [build-system]
 requires = [
-    "setuptools == 78.1.1",
+    "setuptools >= 78.1.1,< 81",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # Generated with zope.meta (https://zopemeta.readthedocs.io/) from:
 # https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
-# 
+#
 # Generated from:
 # https://github.com/zopefoundation/meta/tree/master/config/pure-python
 
@@ -14,6 +14,7 @@ build-backend = "setuptools.build_meta"
 [tool.coverage.run]
 branch = true
 source = ["zope.pytestlayer"]
+parallel = true
 
 [tool.coverage.report]
 fail_under = 98

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
-# Generated from:
-# https://github.com/zopefoundation/meta/tree/master/config/pure-python
+# Generated with zope.meta (https://zopemeta.readthedocs.io/) from:
+# https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 
 [flake8]
 doctests = 1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name='zope.pytestlayer',
     version='9.1.dev0',
 
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     install_requires=[
         'pytest >= 8',
         'setuptools',
@@ -48,11 +48,11 @@ setup(
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Programming Language :: Python :: Implementation",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,17 @@
+"""
+Coverage sitecustomize - enable coverage for subprocess started via
+subprocess.Popen
+"""
+import atexit
+import os
+
+
+# Check if coverage subprocess tracking is enabled
+if 'COVERAGE_PROCESS_START' in os.environ:
+    import coverage
+
+    # Start coverage in this subprocess
+    cov = coverage.Coverage(
+        config_file=os.environ['COVERAGE_PROCESS_START'])
+    cov.start()
+    atexit.register(cov.save)

--- a/src/zope/pytestlayer/_compat.py
+++ b/src/zope/pytestlayer/_compat.py
@@ -2,10 +2,10 @@
 def _searchbases(cls, accum):
     # Simulate the "classic class" search order.
     if cls in accum:
-        return
+        return  # pragma: no cover
     accum.append(cls)
     for base in cls.__bases__:
-        _searchbases(base, accum)
+        _searchbases(base, accum)  # pragma: no cover
 
 
 def getmro(cls):

--- a/src/zope/pytestlayer/tests/conftest.py
+++ b/src/zope/pytestlayer/tests/conftest.py
@@ -1,3 +1,6 @@
-def pytest_ignore_collect(path, config):
-    if path.strpath.endswith('fixture'):
+import pathlib
+
+
+def pytest_ignore_collect(collection_path: pathlib.Path, config):
+    if str(collection_path).endswith('fixture'):
         return True

--- a/src/zope/pytestlayer/tests/test_doctest.py
+++ b/src/zope/pytestlayer/tests/test_doctest.py
@@ -5,7 +5,7 @@ class Dummy:
     """This class has a doctest.
 
     It tests the workaround for
-    https://github.com/zope/zope.pytestlayer/issues/4
+    https://github.com/zopefoundation/zope.pytestlayer/issues/4
 
     >>> print('foobar.')
     foobar.

--- a/src/zope/pytestlayer/tests/test_integration.py
+++ b/src/zope/pytestlayer/tests/test_integration.py
@@ -1,4 +1,6 @@
+import os
 import os.path
+import pathlib
 import re
 import subprocess
 import sys
@@ -14,13 +16,16 @@ normalizers = [
     (r'\.py::(test_suite)::/', r'.py <- \1: /'),
     (r'\.py::(test)', r'.py:NN: \1'),
     (r'\.py::(.*Test)::', r'.py:NN: \1.'),
-    # Compatibility with pytest >= 7.3 which adds this line:
     (r'configfile: pytest.ini', ''),
+    (r'cachedir:.*\n', ''),
+    (r'rootdir:.*\n', ''),
     # With pytest >= 3.3.0 progress is reported after a test result.
     # matches [NNN%], [ NN%] and [  N%]
     (r'PASSED \[\s*\d{1,3}%\]', 'PASSED'),
-    # needed to omit all other loaded plugins.
-    (r'plugins:.*(zope.pytestlayer).*\n', 'plugins: zope.pytestlayer\n'),
+    # Omit coverage warnings:
+    (r'.*CoverageWarning:.*', ''),
+    (r'.*slug="module-not-measured".*', ''),
+    (r'.*slug="no-data-collected".*', ''),
 ]
 
 
@@ -44,22 +49,38 @@ def where(request):
 
 def run_pytest(name, *args):
     cmd = [
-        sys.argv[0], '-vs', '-p', 'no:removestalebytecode',
+        sys.executable, '-m', 'pytest', '-vs', '-p', 'no:removestalebytecode',
         '--disable-pytest-warnings',
         os.path.join(os.path.dirname(__file__), 'fixture', name),
     ]
     cmd.extend(args)
+
+    # Set up environment for coverage in subprocess
+    env = os.environ.copy()
+
+    # If running under coverage, enable subprocess tracking
+    if 'COVERAGE_FILE' in env:
+        env['COVERAGE_PROCESS_START'] = 'pyproject.toml'
+        # Add project root to PYTHONPATH so sitecustomize.py is found
+        project_root = str(pathlib.Path(__file__).parent.parent.parent.parent)
+        env['PYTHONPATH'] = project_root + ':' + env.get('PYTHONPATH', '')
+    else:
+        # Just make brach coverage happy as this branch is only hit when
+        # running without coverage
+        pass  # pragma: no cover
+
     process = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT)
+        stderr=subprocess.STDOUT,
+        env=env)
     output = process.stdout.read().decode('latin-1')
     for pattern, replacement in normalizers:
         output = re.sub(pattern, replacement, output)
-    lines = output.splitlines(True)
+    lines = output.strip().splitlines(True)
     # Sometimes the output ends with an escape sequence so omitting them to
     # make tests happy:
-    if lines[-1] == '\x1b[?1034h':
+    if lines[-1] == '\x1b[?1034h':  # pragma: no cover
         lines.pop(-1)
     return lines
 
@@ -72,7 +93,6 @@ def join(lines, start=4, end=1):
 def test_single_layer(where):
     lines = run_pytest('single_layer')
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 1 item
 src/zope/pytestlayer/tests/fixture/single_layer/test_core.py:NN: FooTest.test_dummy single_layer.test_core.FooLayer
 Set up single_layer.test_core.FooLayer in N.NNN seconds.
@@ -87,7 +107,6 @@ Tear down single_layer.test_core.FooLayer in N.NNN seconds.
 def test_single_layer_with_unattached_base_layer(where):
     lines = run_pytest('single_layer_with_unattached_base_layer')
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 1 item
 src/zope/pytestlayer/tests/fixture/single_layer_with_unattached_base_layer/test_core.py:NN: FooTest.test_dummy single_layer_with_unattached_base_layer.test_core.BarLayer
 Set up single_layer_with_unattached_base_layer.test_core.BarLayer in N.NNN seconds.
@@ -109,7 +128,6 @@ def test_single_layer_with_unattached_base_layer_select_layer(where):
         'single_layer_with_unattached_base_layer', '-k', 'BarLayer'
     )
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 1 item
 src/zope/pytestlayer/tests/fixture/single_layer_with_unattached_base_layer/test_core.py:NN: FooTest.test_dummy single_layer_with_unattached_base_layer.test_core.BarLayer
 Set up single_layer_with_unattached_base_layer.test_core.BarLayer in N.NNN seconds.
@@ -129,7 +147,6 @@ Tear down single_layer_with_unattached_base_layer.test_core.BarLayer in N.NNN se
 def test_single_layer_in_two_modules(where):
     lines = run_pytest('single_layer_in_two_modules')
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 2 items
 src/zope/pytestlayer/tests/fixture/single_layer_in_two_modules/test_core.py:NN: FooTest.test_dummy single_layer_in_two_modules.test_core.FooLayer
 Set up single_layer_in_two_modules.test_core.FooLayer in N.NNN seconds.
@@ -148,7 +165,6 @@ Tear down single_layer_in_two_modules.test_core.FooLayer in N.NNN seconds.
 def test_single_layered_suite(where):
     lines = run_pytest('single_layered_suite')
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 1 item
 src/zope/pytestlayer/tests/fixture/single_layered_suite/test_core.py <- test_suite: /src/zope/pytestlayer/tests/fixture/single_layered_suite/doctest.txt single_layered_suite.test_core.FooLayer
 Set up single_layered_suite.test_core.FooLayer in N.NNN seconds.
@@ -163,7 +179,6 @@ Tear down single_layered_suite.test_core.FooLayer in N.NNN seconds.
 def test_shared_with_layered_suite(where):
     lines = run_pytest('shared_with_layered_suite')
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 2 items
 src/zope/pytestlayer/tests/fixture/shared_with_layered_suite/test_core.py:NN: FooTest.test_dummy shared_with_layered_suite.test_core.FooLayer
 Set up shared_with_layered_suite.test_core.FooLayer in N.NNN seconds.
@@ -182,7 +197,6 @@ Tear down shared_with_layered_suite.test_core.FooLayer in N.NNN seconds.
 def test_with_and_without_layer(where):
     lines = run_pytest('with_and_without_layer')
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 2 items
 src/zope/pytestlayer/tests/fixture/with_and_without_layer/test_core.py:NN: UnitTest.test_dummy PASSED
 src/zope/pytestlayer/tests/fixture/with_and_without_layer/test_core.py:NN: FooTest.test_dummy with_and_without_layer.test_core.FooLayer
@@ -198,7 +212,6 @@ Tear down with_and_without_layer.test_core.FooLayer in N.NNN seconds.
 def test_two_dependent_layers(where):
     lines = run_pytest('two_dependent_layers')
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 2 items
 src/zope/pytestlayer/tests/fixture/two_dependent_layers/test_core.py:NN: FooTest.test_dummy two_dependent_layers.test_core.FooLayer
 Set up two_dependent_layers.test_core.FooLayer in N.NNN seconds.
@@ -221,7 +234,6 @@ Tear down two_dependent_layers.test_core.FooLayer in N.NNN seconds.
 def test_two_dependent_layered_suites(where):
     lines = run_pytest('two_dependent_layered_suites')
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 2 items
 src/zope/pytestlayer/tests/fixture/two_dependent_layered_suites/test_core.py <- test_suite: /src/zope/pytestlayer/tests/fixture/two_dependent_layered_suites/foo.txt two_dependent_layered_suites.test_core.FooLayer
 Set up two_dependent_layered_suites.test_core.FooLayer in N.NNN seconds.
@@ -244,7 +256,6 @@ Tear down two_dependent_layered_suites.test_core.FooLayer in N.NNN seconds.
 def test_two_independent_layers(where):
     lines = run_pytest('two_independent_layers')
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 2 items
 src/zope/pytestlayer/tests/fixture/two_independent_layers/test_core.py:NN: FooTest.test_dummy two_independent_layers.test_core.FooLayer
 Set up two_independent_layers.test_core.FooLayer in N.NNN seconds.
@@ -267,7 +278,6 @@ Tear down two_independent_layers.test_core.BarLayer in N.NNN seconds.
 def test_keep_layer_across_test_classes(where):
     lines = run_pytest('keep_layer_across_test_classes')
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 3 items
 src/zope/pytestlayer/tests/fixture/keep_layer_across_test_classes/test_core.py:NN: FooTest.test_dummy order_by_layer.test_core.FooLayer
 Set up keep_layer_across_test_classes.test_core.FooLayer in N.NNN seconds.
@@ -292,13 +302,12 @@ src/zope/pytestlayer/tests/fixture/keep_layer_across_test_classes/test_core.py:N
 testTearDown bar
 Tear down keep_layer_across_test_classes.test_core.BarLayer in N.NNN seconds.
 """ == join(lines)
-    assert '=== 3 passed' in lines[-1]
+    assert '=== 3 passed' in lines[-1]  # pragma: no cover
 
 
 def test_order_by_layer(where):
     lines = run_pytest('order_by_layer')
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 4 items
 src/zope/pytestlayer/tests/fixture/order_by_layer/test_core.py:NN: FooTest.test_dummy order_by_layer.test_core.FooLayer
 Set up order_by_layer.test_core.FooLayer in N.NNN seconds.
@@ -336,7 +345,6 @@ Tear down order_by_layer.test_core.FooLayer in N.NNN seconds.
 def test_order_with_layered_suite(where):
     lines = run_pytest('order_with_layered_suite')
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 6 items
 src/zope/pytestlayer/tests/fixture/order_with_layered_suite/test_core.py:NN: FooTest.test_dummy order_with_layered_suite.test_core.FooLayer
 Set up order_with_layered_suite.test_core.FooLayer in N.NNN seconds.
@@ -386,7 +394,6 @@ Tear down order_with_layered_suite.test_core.FooLayer in N.NNN seconds.
 def test_order_with_layered_suite_select_layer(where):
     lines = run_pytest('order_with_layered_suite', '-k', 'FooLayer')
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 6 items / 2 deselected / 4 selected
 src/zope/pytestlayer/tests/fixture/order_with_layered_suite/test_core.py:NN: FooTest.test_dummy order_with_layered_suite.test_core.FooLayer
 Set up order_with_layered_suite.test_core.FooLayer in N.NNN seconds.
@@ -426,7 +433,6 @@ Tear down order_with_layered_suite.test_core.FooLayer in N.NNN seconds.
 def test_order_with_layered_suite_select_doctest(where):
     lines = run_pytest('order_with_layered_suite', '-k', 'foobar and txt')
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 6 items / 5 deselected / 1 selected
 src/zope/pytestlayer/tests/fixture/order_with_layered_suite/test_core.py <- test_suite: /src/zope/pytestlayer/tests/fixture/order_with_layered_suite/foobar.txt order_with_layered_suite.test_core.FooLayer
 Set up order_with_layered_suite.test_core.FooLayer in N.NNN seconds.
@@ -451,7 +457,6 @@ Tear down order_with_layered_suite.test_core.FooLayer in N.NNN seconds.
 def test_works_even_without_any_setup_or_teardown_methods(where):
     lines = run_pytest('no_setup_or_teardown')
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 1 item
 src/zope/pytestlayer/tests/fixture/no_setup_or_teardown/test_core.py:NN: FooTest.test_dummy PASSED
 """ == join(lines)
@@ -469,7 +474,6 @@ has no __bases__ attribute. Layers may be of two sorts: class or instance with _
 def test_creating_different_fixtures_for_layers_with_the_same_name(where):
     lines = run_pytest('layers_with_same_name')
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 2 items
 src/zope/pytestlayer/tests/fixture/layers_with_same_name/test_core.py:NN: FooTest.test_dummy layers_with_same_name.test_core.TestLayer
 Set up layers_with_same_name.test_core.TestLayer in N.NNN seconds.
@@ -491,7 +495,6 @@ def test_selection_of_doctest_names(where):
 def test_fixture_create_allows_overriding_names(where):
     lines = run_pytest('custom_fixture_name')
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 2 items
 src/zope/pytestlayer/tests/fixture/custom_fixture_name/test_core.py:NN: test_can_access_layer_via_fixture custom_fixture_name.test_core.FooLayer
 Set up custom_fixture_name.test_core.FooLayer in N.NNN seconds.
@@ -510,7 +513,6 @@ Tear down custom_fixture_name.test_core.FooLayer in N.NNN seconds.
 def test_if_session_fixture_is_used_class_fixtures_are_ignored(where):
     lines = run_pytest('session_fixture')
     assert """\
-plugins: zope.pytestlayer
 collecting ... collected 2 items
 src/zope/pytestlayer/tests/fixture/session_fixture/test_core.py:NN: test_can_access_layer_via_fixture session_fixture.test_core.FooLayer
 Set up session_fixture.test_core.FooLayer in N.NNN seconds.

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,15 @@
-# Generated from:
-# https://github.com/zopefoundation/meta/tree/master/config/pure-python
+# Generated with zope.meta (https://zopemeta.readthedocs.io/) from:
+# https://github.com/zopefoundation/meta/tree/master/src/zope/meta/pure-python
 [tox]
 minversion = 3.18
 envlist =
     release-check
     lint
-    py39
     py310
     py311
     py312
     py313
+    py314
     pypy3
     docs
     coverage
@@ -19,7 +19,7 @@ usedevelop = true
 package = wheel
 wheel_build_env = .pkg
 deps =
-    setuptools == 78.1.1
+    setuptools >= 78.1.1,< 81
     pytest
     pytest-cov
     pytest-remove-stale-bytecode
@@ -41,7 +41,7 @@ description = ensure that the distribution is ready to release
 basepython = python3
 skip_install = true
 deps =
-    setuptools == 78.1.1
+    setuptools >= 78.1.1,< 81
     wheel
     twine
     build
@@ -51,7 +51,7 @@ deps =
 commands_pre =
 commands =
     check-manifest
-    check-python-versions --only setup.py,tox.ini,.github/workflows/tests.yml
+    check-python-versions --only pyproject.toml,setup.py,tox.ini,.github/workflows/tests.yml
     python -m build --sdist --no-isolation
     twine check dist/*
 

--- a/tox.ini
+++ b/tox.ini
@@ -83,8 +83,11 @@ deps =
     pytest
     pytest-cov
     pytest-remove-stale-bytecode
+setenv =
+    COVERAGE_FILE = {toxinidir}/.coverage
 commands =
     mkdir -p {toxinidir}/parts/htmlcov
-    pytest --cov=src --cov-report=html []
+    coverage erase
+    pytest --cov=src --cov-report= -vs []
     coverage html
     coverage report


### PR DESCRIPTION
- **Configuring for pure-python**
- **Update Python version support.**

open issues:

- [x] find out why coverage has dropped drastically.
   - [x] seems like https://github.com/zopefoundation/zope.pytestlayer/blob/a14fbe8db583ec4bd048d5ba55add51be76beaf3/src/zope/pytestlayer/tests/test_integration.py#L52-L55 ignores coverage settings so theses calls are not under coverage
