### PR TITLE
Update pytest API usage after deprecation in 9.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Change log for zope.pytestlayer
 9.2 (unreleased)
 ================
 
-- Nothing changed yet.
+- Add compatibility for ``pytest >= 9.1``, requiring at least that version.
 
 
 9.1 (2025-12-03)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
 
     python_requires='>=3.10',
     install_requires=[
-        'pytest >= 8',
+        'pytest >= 9.1',
         'setuptools',
         'zope.dottedname',
     ],

--- a/src/zope/pytestlayer/fixture.py
+++ b/src/zope/pytestlayer/fixture.py
@@ -207,7 +207,8 @@ def parsefactories(collector, layer):
         name = get_fixture_name(layer, scope='function')
         module = types.ModuleType(name)
         module.__dict__.update(ns)
-        collector.session._fixturemanager.parsefactories(module, '')
+        collector.session._fixturemanager.parsefactories(
+            holder=module, node=collector.session)
 
 
 def raise_if_bad_layer(layer):


### PR DESCRIPTION
After pytest-dev/pytest#14098 / pytest-9.1, zope.pytestlayer now causes this warning:

```
src/zope/pytestlayer/fixture.py:210: PytestRemovedIn10Warning: Passing nodeid string to parsefactories is deprecated. Use parsefactories(holder=obj, node=node) instead.
    collector.session._fixturemanager.parsefactories(module, '')
```

Note that pytest-9.1 introduced the new parameter style and deprecated the old parameter style at the same time. So we'd probably have to do an `importlib.metadata.version` check to change the way we call `parsefactories()` if we still want to support pytest-8.x. I haven't done that yet because I'm not sure whether it's actually worth doing.
